### PR TITLE
This branch will be for changing how rendering happens

### DIFF
--- a/System/Files/Filesystem.gd
+++ b/System/Files/Filesystem.gd
@@ -56,10 +56,11 @@ static func load_resource(path:String):
 
 static func load_image_from_path(path:String) -> Image:
 	# TODO - we should try the file before the resource to allow modding
-	var resource = load_resource(path)
-	if resource:
-		print("resource found")
-		return resource
+	if OS.has_feature("standalone") or OS.has_feature("HTML5"):
+		var resource = load_resource(path)
+		if resource:
+			print("resource found")
+			return resource
 	var f = File.new()
 	var err = f.open(path, File.READ)
 	var image:Image
@@ -92,6 +93,7 @@ static func load_atlas_frames(path:String, horizontal=1, vertical=1, length=1) -
 	else:
 		texture = ImageTexture.new()
 		texture.create_from_image(image, 0)
+		pass
 		
 	if not texture or not image:
 		return []


### PR DESCRIPTION
 - Any asset loaded from the file system while in godot editor was being loaded with filters, which messes up the pink background for the back button
 - We've now forced the editor to always load from the filesystem with no filters; turnabout substitution assets look bad for some reason though
 - Also in this branch, I would like to experiment with a viewport so that the game is rendered upscaled but the debugger can be in a higher resolution