### PR TITLE
feat: implement setvar command

### DIFF
--- a/System/WrightScript/Commands/Variables.gd
+++ b/System/WrightScript/Commands/Variables.gd
@@ -27,7 +27,9 @@ func ws_delvar(script, arguments):
 #        value = EVAL_EXPR(EXPR(" ".join(args)))
 #        assets.variables[variable]=value
 func ws_set_ex(script, arguments):
-	pass
+	var variableName = arguments.pop_front()
+	var value = WSExpression.EVAL_STR(Commands.join(arguments))
+	main.stack.variables.set_val(variableName, value)
 	
 func ws_setvar_ex(script, arguments):
 	return ws_set_ex(script, arguments)

--- a/tests/vars.txt
+++ b/tests/vars.txt
@@ -18,3 +18,8 @@ mulvar i 3
 "{$i}=7.8"
 subvar i 0.6
 "{$i}=7.2"
+
+setvar_ex i 5+5
+"{$i}=10"
+setvar_ex i 1 == 1
+"{$i}=true"


### PR DESCRIPTION
This is a very simplistic implementation to the the `setvar` and `setvarex` commands that use the WSExpression class to evaluate the expressions. It even comes with a test. 