### PR TITLE
_music_loop is supposed to reset whenever the mus command is called

### DIFF
--- a/System/WrightScript/Commands/Audio.gd
+++ b/System/WrightScript/Commands/Audio.gd
@@ -5,12 +5,16 @@ var main
 func _init(commands):
 	main = commands.main
 
+# We always reset the _music_loop value, which means if you want a looping track
+# you always have to call it AFTER the mus command
 func ws_mus(script, arguments):
 	if not len(arguments):
 		MusicPlayer.stop_music()
 	else:
+		var song = Commands.join(arguments)
+		main.stack.variables.set_val("_music_loop", song)
 		MusicPlayer.play_music(
-			Filesystem.path_join("music",Commands.join(arguments)), 
+			Filesystem.path_join("music",song), 
 			script.root_path
 		)
 


### PR DESCRIPTION
It's a bit weird, but the mus command will always set the looping track as the file that was played. If you want a different looping track you have to set _music_loop after starting the intro with mus.