### PR TITLE
Moved some of the file lookup from WrightObject to PWSprite, so that …

### DIFF
--- a/System/Scene/WrightObject.gd
+++ b/System/Scene/WrightObject.gd
@@ -142,36 +142,17 @@ func add_sprite(sprite_key, sprite_template):
 		"base": base_path,
 		"variant": variant_path
 	})
-	var search_paths = [search_path]
-	if search_path.ends_with(".png"):
-		search_paths.append(search_path.substr(0,search_path.length()-4))
-	while "//" in search_path:
-		search_path = search_path.replace("//", "/")
-		search_paths.append(search_path)
-	var filename
-	for path in search_paths:
-		print(path)
-		filename = Filesystem.lookup_file(
-			path,
-			root_path,
-			[],
-			false
-		)
-		if not filename:
-			sprite_paths_searched.append(path)
-			continue
-		break
-	if not filename:
-		return
 	var sprite = PWSpriteC.new()
 	sprite.name = "PWSprite:"+base_path+";"+variant_path
+	# TODO handle template rects better
 	if template["rect"] and not template["rect"] is Array and not template["rect"] is PoolStringArray:
 		if "(" in template["rect"]:
 			template["rect"] = template["rect"].replace("(","").replace(")","")
 		template["rect"] = template["rect"].split(",")
-	sprite.load_animation(filename, null, template["rect"])
-	sprites[sprite_key] = sprite
-	return sprite
+	sprite_paths_searched = sprite.load_animation(search_path, root_path, template["rect"])
+	if not sprite_paths_searched:
+		sprites[sprite_key] = sprite
+		return sprite
 	
 func load_sprites(template, sprite_key=null):
 	sprite_paths_searched = []

--- a/System/UI/CourtRecord.gd
+++ b/System/UI/CourtRecord.gd
@@ -233,9 +233,8 @@ func load_page():
 
 # TODO use variables for positioning and art assets
 func load_page_zoom():
-	var zoombg_path = Filesystem.lookup_file("art/%s.png" % stack.variables.get_string("ev_z_bg"), root_path)
 	var zoombg = PWSprite.new()
-	zoombg.load_animation(zoombg_path)
+	zoombg.load_animation("art/%s.png" % stack.variables.get_string("ev_z_bg"), root_path)
 	add_child(zoombg)
 	zoombg.position = Vector2(
 		stack.variables.get_int("ev_z_bg_x"),
@@ -266,17 +265,9 @@ func load_page_zoom():
 			"name": key_name, "desc": key_desc, "pic": key_pic, "check": key_check
 		}
 		var pic = PWSprite.new()
-		var ev_path = Filesystem.lookup_file(
-			"art/ev/"+key_pic+".png",
-			self.root_path
-		)
-		if not ev_path:
-			ev_path = Filesystem.lookup_file(
-				"art/ev/envelope.png",
-				self.root_path
-			)
 		pic.name = "ZoomedEv"+key_pic
-		pic.load_animation(ev_path)
+		if pic.load_animation("art/ev/"+key_pic+".png", root_path) is Array:
+			pic.load_animation("art/ev/envelope.png", root_path)
 		pic.rescale(
 			stack.variables.get_int("ev_big_width")+1,
 			stack.variables.get_int("ev_big_height")+1

--- a/System/UI/TextboxBackdrop.gd
+++ b/System/UI/TextboxBackdrop.gd
@@ -13,8 +13,7 @@ func _ready():
 		var sprite = PWSpriteC.new()
 		sprite.name = "PWSprite:"+bg
 		sprite.pivot_center = false
-		var found_path = Filesystem.lookup_file("art/"+bg+".png", get_parent().main.stack.scripts[-1].root_path, ["png"])
-		sprite.load_animation(found_path, null, null)
+		sprite.load_animation("art/"+bg+".png", get_parent().main.stack.scripts[-1].root_path)
 		add_child(sprite)
 		move_child(sprite, 0)
 		get_node("Textbox2").queue_free()


### PR DESCRIPTION
…PWSprite can independantyly look up a .txt file that goes along with a sprite. Ensures that if a case author overwrites the sprite but not the txt file it can still match them up. May have messed up some of the error messages when files are missing. but those need another pass anyway.