### PR TITLE
Lower the z value for the investigate menu background and don't paren…

### DIFF
--- a/System/UI/Investigate.gd
+++ b/System/UI/Investigate.gd
@@ -39,8 +39,8 @@ func _process(dt):
 			wrightscript,
 			"bg",
 			{},
-			[bg_script, "y=192"],
-			script_name
+			[bg_script, "y=192", "z="+str(ZLayers.z_sort["uglyarrow"])],
+			null
 		)
 		bg.cannot_save = true
 		for option in enabled_options:


### PR DESCRIPTION
…t it to the investigate menu. This allows a user to place their own background on the second screen (instead of using the _investigate_bg variable which is new in GW)