### PR TITLE
Blockers and screens

### DIFF
--- a/System/Audio/MusicPlayer.gd
+++ b/System/Audio/MusicPlayer.gd
@@ -96,7 +96,7 @@ var save_properties = [
 	"playing", "root_path", "playing_path", "music_volume"
 ]
 func save_node(data):
-	if playing:
+	if playing and is_instance_valid(audio_player):
 		data["song_position"] = audio_player.get_playback_position()
 
 func load_node(tree, saved_data:Dictionary):

--- a/System/Graphics/Node3D.gd
+++ b/System/Graphics/Node3D.gd
@@ -78,7 +78,7 @@ func _gui_input(event):
 		for mesh in get_node("%Meshes").get_children():
 			var jump_label = mesh.get_label_for_click(u)
 			if jump_label:
-				Commands.call_command("goto", Commands.main.top_script(), [jump_label])
+				Commands.call_command("goto", wrightscript, [jump_label])
 				return true
 	return false
 

--- a/System/Graphics/PWMesh.gd
+++ b/System/Graphics/PWMesh.gd
@@ -35,10 +35,8 @@ func load_mesh():
 
 func add_to_node3d(node3d=null):
 	if not node3d:
-		for screen in ScreenManager.get_screens():
-			var surfs = Commands.get_objects("surf3d", null, Commands.SPRITE_GROUP, screen)
-			if not surfs:
-				continue
+		var surfs = ScreenManager.get_objects("surf3d", null, Commands.SPRITE_GROUP)
+		if surfs:
 			node3d = surfs[0]
 	if not node3d:
 		GlobalErrors.log_error("No surface found for mesh to be put on")

--- a/System/Input/InputController.gd
+++ b/System/Input/InputController.gd
@@ -6,7 +6,7 @@ onready var screens = main.screens
 
 # TODO this is pretty hacky
 func scan_objects(action, button_names=[]):
-	var objects:Array = Commands.get_objects(null)
+	var objects:Array = ScreenManager.top_screen().get_objects()
 	var found_object = null
 	for i in range(objects.size()-1, 0, -1):
 		var ob = objects[i]

--- a/System/Main.gd
+++ b/System/Main.gd
@@ -41,7 +41,6 @@ func reset():
 	MusicPlayer.stop_music()
 	SoundPlayer.stop_sounds()
 	stack.clear_scripts()
-	stack.blockers = []
 	ScreenManager.clear()
 	font_cache.clear()
 	timecounter.reset()
@@ -220,7 +219,11 @@ func _process(_delta):
 		stack.show_in_debugger()
 	emit_signal("frame_drawn")
 
-func top_script():
+func top_script(screen=null):
+	if screen:
+		for i in range(stack.scripts.size()):
+			if stack.scripts[-i].screen == screen:
+				return stack.scripts[-i]
 	if stack.scripts.size() > 0:
 		return stack.scripts[-1]
 	return null

--- a/System/NameSpaces.gd
+++ b/System/NameSpaces.gd
@@ -99,7 +99,7 @@ class Accessor:
 		if not namespace.store[key] is Array:
 			return []
 		return namespace.store[key]
-	func get_val(type=null, default=null):
+	func get_val(type="string", default=null):
 		var val = namespace.get_val(key, NOT_FOUND.new())
 		if access_item != null:
 			if not val is Array:
@@ -199,6 +199,8 @@ func get_accessor(variable:String, namespace:Variables=null, setting=false):
 
 	if not namespace and next and variable:
 		if next == "script":
+			if not script:
+				return get_accessor(variable, Variables.new(), setting)
 			return get_accessor(variable, script.variables, setting)
 		if next == "game":
 			return get_accessor(variable, game_namespace, setting)

--- a/System/NameSpaces.gd
+++ b/System/NameSpaces.gd
@@ -205,7 +205,7 @@ func get_accessor(variable:String, namespace:Variables=null, setting=false):
 		if next == "game":
 			return get_accessor(variable, game_namespace, setting)
 		# See if next is an object
-		for object in Commands.get_objects(next):
+		for object in ScreenManager.get_objects(next):
 			return get_accessor(variable, object.variables, setting)
 
 	if not namespace:

--- a/System/Saving/SaveState.gd
+++ b/System/Saving/SaveState.gd
@@ -127,8 +127,6 @@ static func load_game(tree:SceneTree, filename:String):
 
 	ScreenManager.clear()
 
-	var after_load = []
-
 	for ob_data in data:
 		GlobalErrors.log_info("Load Object %s" % ob_data["original_node_path"])
 		print(ob_data)
@@ -141,7 +139,6 @@ static func load_game(tree:SceneTree, filename:String):
 		else:
 			continue
 		_load_node(tree, ob, ob_data)
-		after_load.append([ob, ob_data])
 		tree.connect("idle_frame", ob, "after_load", [tree, ob_data], tree.CONNECT_ONESHOT)
 	#for ob_data_arr in after_load:
 	#	ob_data_arr[0].after_load(tree, ob_data_arr[1])

--- a/System/Scene/ObjectFactory.gd
+++ b/System/Scene/ObjectFactory.gd
@@ -418,7 +418,8 @@ func create_from_template(
 		if not parent_name is String:
 			parent = [parent_name]
 		else:
-			parent = Commands.get_objects(parent_name)
+			# TODO we should really be getting based on the script's screen
+			parent = ScreenManager.get_objects(parent_name, null, null)
 		if not parent:
 			parent = script.screen
 			GlobalErrors.log_error("Failed to find parent:"+parent_name, {"frame": script.get_frame(null)})

--- a/System/Scene/Screen.gd
+++ b/System/Scene/Screen.gd
@@ -37,6 +37,31 @@ func clear(top=true, bottom=true):
 		remove_child(child)
 		child.queue_free()
 
+func get_objects(script_name=null, last=null, group=null):
+	if not get_tree():
+		return []
+	if last:
+		if Commands.last_object and not Commands.last_object.is_queued_for_deletion():
+			if Commands.last_object in get_children():
+				return [Commands.last_object]
+	var objects = []
+	for object in get_children():
+		if object.is_queued_for_deletion():
+			continue
+		if group and not object.is_in_group(group):
+			continue
+		if not script_name or ("script_name" in object and object.script_name == script_name):
+			objects.append(object)
+		if object.has_method("get_meshes"):
+			for mesh in object.get_meshes():
+				if not script_name or mesh.script_name == script_name:
+					objects.append(mesh)
+	return objects
+
+func delete_objects(script_name=null, last=null, group=null):
+	for o in get_objects(script_name, last, group):
+		o.queue_free()
+
 #func sort_children():
 #	var children = get_children()
 #	children.sort_custom(self, "compare")

--- a/System/Scene/ScreenManager.gd
+++ b/System/Scene/ScreenManager.gd
@@ -38,13 +38,49 @@ func get_screens():
 			screen_array.append(screen)
 	return screen_array
 
+func get_objects(script_name=null, last=null, group=null):
+	var objects = []
+	var screens = get_screens()
+	for i in range(screens.size()):
+		for object in screens[-i].get_objects(script_name, last, group):
+			objects.append(object)
+	return objects
+
+func delete_objects(script_name=null, last=null, group=null):
+	for screen in get_screens():
+		screen.delete_objects(script_name, last, group)
+
 func _on_tree_changed():
 	if not is_instance_valid(_main_screen):
 		_init_screens()
 
 func add_screen(name="Screen"):
 	var screen = Screen.new()
+	screen.name = name
 	screens.add_child(screen)
+	return screen
+
+func get_screen(name):
+	for screen in get_screens():
+		if screen.name == name:
+			if name == "MainScreen":
+				pass
+			return screen
+		# for save/load - when a node wasn't named correctly it gets @ added in its name
+		# you can't add a node explicitly with @ in the nane. so do fuzzy matching here
+		if screen.name.replace("@","") == name.replace("@",""):
+			return screen
+	return null
+
+func has_screen(name):
+	if get_screen(name) != null:
+		return true
+	return false
+
+func get_or_create(screen_name):
+	var screen = get_screen(screen_name)
+	if not screen:
+		screen = add_screen(screen_name)
 	return screen
 
 func clear():

--- a/System/Testing/Testing.gd
+++ b/System/Testing/Testing.gd
@@ -17,10 +17,10 @@ static func command():
 """
 
 static func objects(name=null):
-	return Commands.get_objects(name)
+	return ScreenManager.get_objects(name)
 
 static func textbox():
-	var obs = Commands.get_objects(null, null, Commands.TEXTBOX_GROUP)
+	var obs = ScreenManager.get_objects(null, null, Commands.TEXTBOX_GROUP)
 	if obs:
 		return obs[0]
 

--- a/System/UI/CourtRecord.gd
+++ b/System/UI/CourtRecord.gd
@@ -69,7 +69,7 @@ func _process(dt):
 	if not evbg_path:
 		evbg_path = stack.variables.get_string("ev_mode_bg_evidence")
 	var bg = ObjectFactory.create_from_template(
-		main.top_script(),
+		wrightscript,
 		"graphic",
 		{},
 		[evbg_path],
@@ -118,7 +118,7 @@ func load_back_button():
 		if not stack.variables.get_truth("_cr_back_button", true):
 			return
 	var back_button = ObjectFactory.create_from_template(
-		main.top_script(),
+		wrightscript,
 		"button",
 		{
 			"sprites": {
@@ -159,7 +159,7 @@ func load_page_button():
 		return
 	var next_page = pages[cur_i]
 	var b = ObjectFactory.create_from_template(
-		main.top_script(),
+		wrightscript,
 		"button",
 		{
 			"sprites": {
@@ -190,7 +190,7 @@ func load_arrow(direction):
 	if direction == "R":
 		pos.x = 241
 	var b = ObjectFactory.create_from_template(
-		main.top_script(),
+		wrightscript,
 		"button",
 		{
 				"sprites": {
@@ -289,7 +289,7 @@ func load_page_zoom():
 		if can_present() and ev_data["presentable"]:
 			select(ev_data["tag"])
 			var present_button = ObjectFactory.create_from_template(
-				main.top_script(),
+				wrightscript,
 				"button",
 				{
 					"sprites": {
@@ -317,7 +317,7 @@ func load_check_button(ev_data):
 		return
 	var check_img = stack.variables.get_string("ev_check_img")
 	var check_button = ObjectFactory.create_from_template(
-		main.top_script(),
+		wrightscript,
 		"button",
 		{
 			"sprites": {
@@ -356,7 +356,7 @@ func load_page_overview():
 			break
 		count += 1
 		var ev_button = ObjectFactory.create_from_template(
-			main.top_script(),
+			wrightscript,
 			"button",
 			{
 				"sprites": {

--- a/System/UI/Examine.gd
+++ b/System/UI/Examine.gd
@@ -42,13 +42,13 @@ func _ready():
 	wait_signal = "tree_exited"
 	var use_objects = main.stack.variables.get_string("_examine_use", null)
 	if not use_objects:
-		bg_obs_original = Commands.get_objects(null, null, Commands.BG_GROUP)
+		bg_obs_original = get_screen().get_objects(null, null, Commands.BG_GROUP)
 	else:
-		bg_obs_original = Commands.get_objects(use_objects, null, Commands.SPRITE_GROUP)
+		bg_obs_original = get_screen().get_objects(use_objects, null, Commands.SPRITE_GROUP)
 	if not bg_obs_original:
 		# We treid to find backgrounds to use and found none.
 		# As a failsafe, use any background objects that are on the second screen
-		for ob in Commands.get_objects(null, null, Commands.BG_GROUP):
+		for ob in get_screen().get_objects(null, null, Commands.BG_GROUP):
 			if ob.position.y >= 192:
 				bg_obs_original.append(ob)
 	# TODO don't do this if someone has scrolled a screen down?
@@ -90,7 +90,7 @@ func setup_crosshair():
 	var cross_img = main.stack.variables.get_string("_examine_cursor_img", null)
 	if cross_img:
 		cross_img = ObjectFactory.create_from_template(
-			get_tree().root.get_node("Main").top_script(),
+			wrightscript,
 			"graphic",
 			{
 				"sprites": {
@@ -197,7 +197,7 @@ func build_regions():
 
 func ws_check_from_examine(script, arguments):
 	queue_free()
-	var label = fail
+	var label = ""
 	if current_region:
 		label = current_region.label
 	stack.variables.set_val("_examine_clickx", str(crosshair.real_position().x))
@@ -206,7 +206,7 @@ func ws_check_from_examine(script, arguments):
 		"goto",
 		stack.scripts[-1],
 		[
-			label
+			label, "fail=none"
 		]
 	)
 	Commands.call_command("sound_examine_check", stack.scripts[0], [])
@@ -289,7 +289,7 @@ func update():
 	name = script_name
 	if main.stack.variables.get_truth("_examine_showbars", true) and not bars_bg:
 		bars_bg = ObjectFactory.create_from_template(
-			get_tree().root.get_node("Main").top_script(),
+			wrightscript,
 			"graphic",
 			{
 				"sprites": {
@@ -302,7 +302,7 @@ func update():
 		bars_bg.cannot_save = true
 	if allow_back_button and not back_button:
 		back_button = ObjectFactory.create_from_template(
-			get_tree().root.get_node("Main").top_script(),
+			wrightscript,
 			"button",
 			{
 				"sprites": {
@@ -321,7 +321,7 @@ func update():
 		back_button.cannot_save = true
 	if not examine_button:
 		examine_button = ObjectFactory.create_from_template(
-			get_tree().root.get_node("Main").top_script(),
+			wrightscript,
 			"button",
 			{
 				"sprites": {
@@ -343,7 +343,7 @@ func update():
 		if scroll_button:
 			scroll_button.queue_free()
 		scroll_button = ObjectFactory.create_from_template(
-			get_tree().root.get_node("Main").top_script(),
+			wrightscript,
 			"button",
 			{
 				"sprites": {

--- a/System/UI/Investigate.gd
+++ b/System/UI/Investigate.gd
@@ -56,7 +56,7 @@ func load_art(root_path):
 func add_option(option):
 	var rect_offset = relative_positions[option]
 	var button = ObjectFactory.create_from_template(
-		get_tree().root.get_node("Main").top_script(),
+		wrightscript,
 		"button",
 		{"sprites":{
 			"default": {"path": "art/general/talkbuttons.png"},

--- a/System/UI/PWList.gd
+++ b/System/UI/PWList.gd
@@ -57,7 +57,7 @@ func build():
 	add_list_items()
 	if allow_back_button and not back_button:
 		back_button = ObjectFactory.create_from_template(
-			get_tree().root.get_node("Main").top_script(),
+			wrightscript,
 			"button",
 			{
 				"sprites": {
@@ -83,7 +83,7 @@ func add_item(text, result, options={}):
 
 func add_list_items():
 	var bg = ObjectFactory.create_from_template(
-		main.top_script(),
+		wrightscript,
 		"graphic",
 		{},
 		[main.stack.variables.get_string("_list_bg_image", "general/main2")],
@@ -103,7 +103,7 @@ func add_list_items():
 		var result = item[1]
 		var options = item[2]
 		var button = ObjectFactory.create_from_template(
-			get_tree().root.get_node("Main").top_script(),
+			wrightscript,
 			"button",
 			{
 				"sprites": {
@@ -137,7 +137,7 @@ func add_list_items():
 			var lcheck_offset_x = options.get("check_x", check_offset_x)
 			var lcheck_offset_y = options.get("check_y", check_offset_y)
 			var check_ob = ObjectFactory.create_from_template(
-				get_tree().root.get_node("Main").top_script(),
+				wrightscript,
 				"graphic",
 				{
 					"sprites": {

--- a/System/UI/Penalty.gd
+++ b/System/UI/Penalty.gd
@@ -41,20 +41,20 @@ func _ready():
 	add_child(right)
 	add_child(good)
 	add_child(bad)
-	
+
 	threat_section = PWSprite.new()
 	threat_section.from_frame(atlas[2])
 	add_child(threat_section)
-	
+
 func begin():
 	start_value = clamp(start_value, 0, 100)
 	end_value = clamp(end_value, 0, 100)
 	if not threat_amount:
 		threat_section.visible = false
-	
+
 func get_value():
 	return stack.variables.get_float(variable, 100)
-	
+
 func set_value(value):
 	stack.variables.set_val(variable, value)
 	if value <= 0:
@@ -66,7 +66,7 @@ func execute_fail():
 		script = script.split(" ", false, 1)
 		Commands.call_command(
 			"script",
-			Commands.main.top_script(),
+			wrightscript,
 			[script[0], "label="+script[1]]
 		)
 

--- a/System/UI/Textbox.gd
+++ b/System/UI/Textbox.gd
@@ -54,6 +54,11 @@ var MAX_WHILE = 400
 signal run_returned
 signal textbox_deleting
 
+var _screen
+
+func get_screen():
+	return _screen
+
 class TextPack:
 	var text = ""
 	var textbox
@@ -467,6 +472,7 @@ func will_there_be_text(text):
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
+	_screen = get_parent()
 	# Disable showing textbox until there is text, otherwise if we know there will be,
 	# show it immediately
 	if not will_there_be_text(text_to_print):
@@ -815,8 +821,8 @@ func refresh_arrows(script):
 	Commands.call_macro("hide_main_button_all", script, [])
 
 func update_arrows(disable_click=null):
-	var arrows = Commands.get_objects("_main_button_arrow")
-	var buttons = Commands.get_objects("_main_button_fg")
+	var arrows = get_screen().get_objects("_main_button_arrow")
+	var buttons = get_screen().get_objects("_main_button_fg")
 	if not arrows or not buttons:
 		return
 	if disable_click==null:
@@ -871,6 +877,7 @@ static func create_node(saved_data:Dictionary):
 
 func load_node(tree, saved_data:Dictionary):
 	main = tree.get_nodes_in_group("Main")[0]
+	# TODO eliminate top_screen()
 	ScreenManager.top_screen().add_child(self)
 
 func after_load(tree:SceneTree, saved_data:Dictionary):

--- a/System/WrightScript/Commands.gd
+++ b/System/WrightScript/Commands.gd
@@ -49,35 +49,6 @@ func on_screen(screen, nodes):
 			if n.get_screen() == screen:
 				onscreen.append(n)
 	return onscreen
-func get_objects(script_name, last=null, group=SPRITE_GROUP, screen=null):
-	# TODO not sure if this is the right way to handle getting objects
-	if not screen:
-		screen = ScreenManager.top_screen()
-	if not get_tree():
-		return on_screen(screen, [])
-	if last:
-		if last_object and not last_object.is_queued_for_deletion():
-			return on_screen(screen, [last_object])
-		return on_screen(screen, [])
-	var objects = []
-	for object in get_tree().get_nodes_in_group(group):
-		if object.is_queued_for_deletion():
-			continue
-		if not script_name or object.script_name == script_name:
-			objects.append(object)
-		if object.has_method("get_meshes"):
-			for mesh in object.get_meshes():
-				if not script_name or mesh.script_name == script_name:
-					objects.append(mesh)
-	return on_screen(screen, objects)
-
-func delete_object_group(group, screen=null):
-	if not screen:
-		screen = ScreenManager.top_screen()
-	var nodes = on_screen(screen, get_tree().get_nodes_in_group(group))
-	for n in nodes:
-		n.queue_free()
-	#get_tree().call_group_flags(SceneTree.GROUP_CALL_REALTIME, group, "queue_free")
 
 func load_command_engine():
 	main = get_tree().get_nodes_in_group("Main")[0]
@@ -133,7 +104,7 @@ func get_speaking_char(speaking=null):
 		speaking = main.stack.variables.get_string("_speaking", null)
 	if not speaking:
 		return null
-	var characters = get_objects(null, null, CHAR_GROUP)
+	var characters = ScreenManager.get_objects(null, null, CHAR_GROUP)
 	var found = null
 	for character in characters:
 		if character.script_name == speaking:
@@ -220,7 +191,7 @@ func call_command(command, script, arguments):
 		var extern = external_commands["ws_"+command]
 		return extern.callv("ws_"+command, [script, arguments])
 
-	for object in get_objects(null):
+	for object in script.screen.get_objects(null):
 		if object.has_method("ws_"+command):
 			return object.callv("ws_"+command, [script, arguments])
 	return UNDEFINED

--- a/System/WrightScript/Commands/CrossExamination.gd
+++ b/System/WrightScript/Commands/CrossExamination.gd
@@ -62,14 +62,14 @@ func ws_next_statement(script, arguments):
 	var cross = main.cross_exam_script()
 	if cross:
 		cross.next_statement()
-	Commands.delete_object_group(Commands.TEXTBOX_GROUP)
+	script.screen.delete_objects(null, null, Commands.TEXTBOX_GROUP)
 	main.stack.variables.set_val("_in_statement", "true")
 
 func ws_prev_statement(script, arguments):
 	var cross = main.cross_exam_script()
 	if cross:
 		cross.prev_statement()
-	Commands.delete_object_group(Commands.TEXTBOX_GROUP)
+	script.screen.delete_objects(null, null, Commands.TEXTBOX_GROUP)
 
 func ws_statement(script, arguments):
 	var test = Commands.keywords(arguments).get("test", "")
@@ -84,7 +84,7 @@ func ws_statement(script, arguments):
 
 # Press the current statement
 func ws_callpress(script, arguments):
-	Commands.delete_object_group(Commands.TEXTBOX_GROUP)
+	script.screen.delete_objects(null, null, Commands.TEXTBOX_GROUP)
 	var cross_script = main.cross_exam_script()
 	if cross_script:
 		main.stack.variables.set_val("_cross_resume_line", cross_script.line_num+1)
@@ -103,7 +103,7 @@ func ws_resume(script, arguments):
 # Also used internally to trigger creating the court record ui
 func ws_present(script, arguments):
 	# If we are running this, we should be outside of the court record
-	Commands.delete_object_group(Commands.COURT_RECORD_GROUP)
+	script.screen.delete_objects(null, null, Commands.COURT_RECORD_GROUP)
 	# nopress and noclearcross are internal arguments
 	var present = not "nopresent" in arguments
 	arguments.erase("nopresent")
@@ -154,10 +154,10 @@ func ws_showrecord(script, arguments):
 # goto the label '[_statement] maya' if we are in a statement
 # goto the label 'maya' if we are not in a statement
 func ws_callpresent(script, arguments):
-	Commands.delete_object_group(Commands.TEXTBOX_GROUP)
+	script.screen.delete_objects(null, null, Commands.TEXTBOX_GROUP)
 	var ev = main.stack.variables.get_string("_selected")
 	var statement = main.stack.variables.get_string("_statement")
-	var fail = ""
+	var fail = "fail=none"
 	if statement:
 		ev = ev + " " + statement
 		fail = "fail="+StandardVar.COURT_FAIL_LABEL.retrieve()

--- a/System/WrightScript/Commands/Effects.gd
+++ b/System/WrightScript/Commands/Effects.gd
@@ -10,9 +10,9 @@ func ws_grey(script, arguments):
 	var value = Commands.keywords(arguments).get("value", 1)
 	var obs
 	if name:
-		obs = Commands.get_objects(name, null)
+		obs = script.screen.get_objects(name, null)
 	else:
-		obs = Commands.get_objects(null, null)
+		obs = script.screen.get_objects(null, null)
 	for o in obs:
 		if o.has_method("set_grey"):
 			o.set_grey(value)
@@ -38,7 +38,7 @@ func ws_rotate(script, arguments):
 	var axis = kw.get("axis", "z")
 	var name = kw.get("name", null)
 	var nowait = "nowait" in arguments
-	var obj = Commands.get_objects(name)
+	var obj = script.screen.get_objects(name)
 	if obj and obj[0] is PWMesh:
 		obj[0].do_rotate(axis, degrees, speed, nowait)
 

--- a/System/WrightScript/Commands/Fade.gd
+++ b/System/WrightScript/Commands/Fade.gd
@@ -17,18 +17,20 @@ class Fader extends Node:
 		self.end = float(end)
 		self.speed = float(speed)
 		name = "fade"
-		objects = Commands.get_objects(null, false)
+		objects = []
 		if wait:
 			wait_signal = "tree_exited"
 		Pauseable.new(self)
+	func get_screen():
+		return get_parent()
 	func control_all_named(script_name):
-		objects = Commands.get_objects(script_name)
+		objects = get_screen().get_objects(script_name)
 	func control_last():
-		objects = [Commands.get_objects(null, true)]
+		objects = [get_screen().get_objects(null, true)]
 		if objects:
 			objects = [objects[-1]]
 	func control_all(screen):
-		objects = Commands.get_objects(null, true)
+		objects = get_screen().get_objects(null, true)
 	func set_fade():
 		for object in objects:
 			if is_instance_valid(object):
@@ -67,11 +69,11 @@ static func ws_fade(script, arguments):
 	var wait = not "nowait" in arguments
 	var script_name = kw.get("name", null)
 	var fader = Fader.new(start, end, speed, wait)
+	script.screen.add_child(fader)
 	if script_name:
 		fader.control_all_named(script_name)
 	elif last:
 		fader.control_last()
 	else:
 		fader.control_all()
-	script.screen.add_child(fader)
 	return fader

--- a/System/WrightScript/Commands/Graphics.gd
+++ b/System/WrightScript/Commands/Graphics.gd
@@ -54,8 +54,8 @@ func apply_fader(script, obj, arguments):
 	var speed = 5.0
 	var wait = not "nowait" in arguments
 	var fader = FadeLib.Fader.new(start, end, speed, wait)
-	fader.control_all_named(obj.script_name)
 	script.screen.add_child(fader)
+	fader.control_all_named(obj.script_name)
 	if wait:
 		return fader
 	return obj
@@ -75,7 +75,7 @@ func ws_bg(script, arguments):
 	if not main.get_tree():
 		return
 	if not "stack" in arguments:
-		Commands.delete_object_group(Commands.CLEAR_GROUP)
+		script.screen.delete_objects(null, null, Commands.CLEAR_GROUP)
 	var bg:Node = ObjectFactory.create_from_template(script, "bg", {}, arguments)
 	return apply_fader(script, bg, arguments)
 
@@ -93,7 +93,7 @@ func ws_char(script, arguments):
 	var kw = Commands.keywords(arguments)
 	# If we don't "stack" then delete existing character
 	if not "stack" in arguments and not "hide" in arguments:
-		Commands.delete_object_group(Commands.CHAR_GROUP)
+		script.screen.delete_objects(null, null, Commands.CHAR_GROUP)
 	var character = ObjectFactory.create_from_template(
 		script,
 		"portrait",
@@ -111,7 +111,7 @@ func ws_char(script, arguments):
 		})
 	if "hide" in arguments:
 		character.visible = false
-		Commands.delete_object_group(Commands.HIDDEN_CHAR_GROUP)
+		script.screen.delete_objects(null, null, Commands.HIDDEN_CHAR_GROUP)
 		character.add_to_group(Commands.HIDDEN_CHAR_GROUP)
 	# TODO This should maybe be a "property" (variable namespaced on the object)
 	character.char_name = main.stack.variables.get_string(
@@ -145,7 +145,7 @@ func ws_emo(script, arguments):
 		if speaking:
 			characters = [speaking]
 	else:
-		characters = Commands.get_objects(name, false, Commands.CHAR_GROUP)
+		characters = script.screen.get_objects(name, false, Commands.CHAR_GROUP)
 	# TODO should this be the first or last found character if multiple characters have the same name?
 	if characters:
 		characters[0].change_variant(emotion)
@@ -211,7 +211,7 @@ func ws_penalty(script, arguments):
 		delay = 50
 		if not damage_amount or threat:
 			delay = 0
-	Commands.delete_object_group(Commands.PENALTY_GROUP)
+	script.screen.delete_objects(null, null, Commands.PENALTY_GROUP)
 	var penalty = ObjectFactory.create_from_template(
 		script,
 		"penalty",
@@ -251,7 +251,7 @@ func ws_surf3d(script, arguments):
 	surf3d.position.x = x
 	surf3d.position.y = y
 	surf3d.set_size([container_w, container_h, resolution_w, resolution_h])
-	ScreenManager.top_screen().add_child(surf3d)
+	script.screen.add_child(surf3d)
 	if main.examine_meshes:
 		ws_mesh(script, main.examine_meshes[0])
 

--- a/System/WrightScript/Commands/Gui.gd
+++ b/System/WrightScript/Commands/Gui.gd
@@ -83,7 +83,7 @@ func ws_gui(script, arguments):
 
 # NEW (internal)
 func ws_gui_back_clicked(script, arguments):
-	for node in ScreenManager.top_screen().get_children():
+	for node in ScreenManager.get_objects():
 		if node.name == arguments[0]:
 			Commands.call_command("sound_back_button_cancel", script, [])
 			node.queue_free()

--- a/System/WrightScript/Commands/Interface.gd
+++ b/System/WrightScript/Commands/Interface.gd
@@ -99,7 +99,7 @@ func ws_region3d(script, arguments):
 
 func ws_examine3d(script, arguments):
 	if regions_to_add:
-		for obj in Commands.get_objects(null):
+		for obj in script.screen.get_objects(null):
 			if obj is PWMesh:
 				obj.clear_regions()
 				for region in regions_to_add:
@@ -108,7 +108,7 @@ func ws_examine3d(script, arguments):
 		regions_to_add = []
 
 func ws_list(script, arguments):
-	Commands.delete_object_group(Commands.LIST_GROUP)
+	script.screen.delete_objects(null, null, Commands.LIST_GROUP)
 	var noback = "noback" in arguments
 	if noback:
 		arguments.erase("noback")

--- a/System/WrightScript/Commands/Scripting.gd
+++ b/System/WrightScript/Commands/Scripting.gd
@@ -15,7 +15,7 @@ func _init(commands):
 #            assets.variables["_debug"] = "off"
 func ws_debug(script, arguments):
 	print(" OBJECT LIST ")
-	for object in ScreenManager.top_screen().get_children():
+	for object in ScreenManager.get_objects():
 		var script_name = ""
 		if object.get_script():
 			script_name = object.get_script().resource_name

--- a/System/WrightScript/Commands/Scroll.gd
+++ b/System/WrightScript/Commands/Scroll.gd
@@ -27,6 +27,8 @@ class Scroller extends Node:
 		if wait and time_left > 0.02:
 			wait_signal = "tree_exited"
 		Pauseable.new(self)
+	func get_screen():
+		return get_parent()
 	func set_process(enabled):
 		if tween:
 			tween.set_active(enabled)
@@ -83,18 +85,18 @@ class Scroller extends Node:
 		return return_list
 	func control(script_name):
 		controlled = ["control", script_name]
-		objects = Commands.get_objects(script_name)
+		objects = get_screen().get_objects(script_name)
 		if objects:
 			objects = [objects[-1]]
 		pass
 	func control_last():
-		objects = getscrollable(Commands.get_objects(null, true))
+		objects = getscrollable(get_screen().get_objects(null, true))
 		if objects:
 			objects = [objects[0]]
 			controlled = ["control_last", objects[0].get_path()]
 	func control_filter(screen):
 		var new_objects = []
-		for o in getscrollable(Commands.get_objects(null, false)):
+		for o in getscrollable(get_screen().get_objects(null, false)):
 			if screen == "top" and o.position.y >= 192:
 				continue
 			if screen == "bottom" and o.position.y < 192:
@@ -157,12 +159,12 @@ static func ws_scroll(script, arguments):
 	#filter is top or bottom - when no name, only scroll objects on this screen.
 	#if its not top or bottom, it has no effect
 	var scroller = Scroller.new(x, y, z, speed, wait, filter)
+	script.screen.add_child(scroller)
 	if script_name:
 		scroller.control(script_name)
 	elif last:
 		scroller.control_last()
 	else:
 		scroller.control_filter(filter)
-	ScreenManager.top_screen().add_child(scroller)
 	scroller.make_tweens()
 	return scroller

--- a/System/WrightScript/Commands/TextCommands.gd
+++ b/System/WrightScript/Commands/TextCommands.gd
@@ -6,9 +6,7 @@ func _init(commands):
 	main = commands.main
 
 func ws_textbox(script, arguments):
-	#There can be only one!
-	for obj in Commands.get_objects(null, null, Commands.TEXTBOX_GROUP):
-		obj.queue_free()
+	script.screen.delete_objects(null, null, Commands.TEXTBOX_GROUP)
 	var text = Commands.join(arguments)
 	var quote_char = text.substr(0,1)
 	text = text.substr(1,text.length())
@@ -28,7 +26,7 @@ func ws_nt(script, arguments):
 # NEW
 # finds the textbox and makes it continue
 func ws_advance_text(script, arguments):
-	for obj in Commands.get_objects(null, null, Commands.TEXTBOX_GROUP):
+	for obj in ScreenManager.get_objects(null, null, Commands.TEXTBOX_GROUP):
 		obj.click_continue()
 		return
 

--- a/System/WrightScript/Commands/Variables.gd
+++ b/System/WrightScript/Commands/Variables.gd
@@ -39,7 +39,7 @@ func ws_get(script, arguments):
 func ws_getprop(script, arguments):
 	var variable = arguments.pop_front()
 	var kw = Commands.keywords(arguments)
-	for object in Commands.get_objects(kw["name"]):
+	for object in ScreenManager.get_objects(kw["name"]):
 		var value
 		if kw["prop"] in "xy":
 			value = object.position[{"x":0, "y":1}[kw["prop"]]]
@@ -53,7 +53,7 @@ func ws_setprop(script, arguments):
 	var variable = arguments.pop_front()
 	var kw = Commands.keywords(arguments)
 	var value
-	for object in Commands.get_objects(kw["name"]):
+	for object in ScreenManager.get_objects(kw["name"]):
 		if kw["prop"] in "xy":
 			value = main.stack.variables.get_int(variable)
 			object.position[{"x":0, "y":1}[kw["prop"]]] = value

--- a/System/WrightScript/WrightScript.gd
+++ b/System/WrightScript/WrightScript.gd
@@ -16,6 +16,7 @@ var u_id # For saving
 
 var allow_goto_parent_script := false
 var allowed_commands := []  #If any commands are in this list, only process those commands
+var blockers = []  # Script wont be processed while blockers are present
 
 var allow_next_line = true
 
@@ -425,12 +426,30 @@ var save_properties = [
 ]
 func save_node(data):
 	data["variables"] = SaveState._save_node(variables)
+	data["screen_name"] = screen.name
+	data["blockers"] = []
+	for blocker in blockers:
+		if not is_instance_valid(blocker):
+			continue
+		if blocker is SceneTreeTimer:
+			data["blockers"].append({"type": "SceneTreeTimer", "time_left":blocker.time_left})
+		else:
+			if blocker.has_method("get_path"):
+				data["blockers"].append({"type": "Node", "node_path": blocker.get_path()})
 
 static func create_node(saved_data:Dictionary):
 	pass
 
 func load_node(tree, saved_data:Dictionary):
 	SaveState._load_node(tree, variables, saved_data["variables"])
+	screen = ScreenManager.get_or_create(saved_data.get("screen_name", "MainScreen"))
 
 func after_load(tree, saved_data:Dictionary):
-	pass
+	if "blockers" in saved_data:
+		for blocker in saved_data["blockers"]:
+			if blocker["type"] == "SceneTreeTimer":
+				pass # todo implement
+			elif blocker["type"] == "Node":
+				var n = main.get_tree().root.get_node(blocker["node_path"])
+				if n:
+					stack.add_blocker(self, n, true)

--- a/System/WrightScript/WrightScript.gd
+++ b/System/WrightScript/WrightScript.gd
@@ -245,7 +245,6 @@ func resume_cross():
 		return false
 	stack.variables.del_val("_cross_resume_line")
 	stack.variables.del_val("_lastline")
-	stack.variables.set_val("_in_statement", "true")
 	goto_line_number(resume_line)
 	return true
 

--- a/tests/penalty.txt
+++ b/tests/penalty.txt
@@ -1,5 +1,3 @@
-goto test_penalty_script
-
 clear
 set penalty 50
 penalty +24


### PR DESCRIPTION
This change makes blockers and screens a bit more explicit. Gdscript interacting with objects in the scene go through either the ScreenManager (to look at ALL objects) or a specific Screen (to look at objects for only that screen). Rather than trying to manage blocking objects in the stack, each blocking object is assigned to a given script that it is blocking. Save functions updated to support this, saving those blockers along with the script so that loading a scene with multiple screens and blocking objects reproduces more accurately.

A few other bugs were fixed along the way.